### PR TITLE
Fix .editorconfig not compatible with Atom

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,14 +4,11 @@
 root = true
 
 # Unix-style newlines with a newline ending every file
-[*]
-end_of_line = lf
-insert_final_newline = true
-
-
 # Matches multiple files with brace expansion notation
 # Set default charset
 [*]
+end_of_line = lf
+insert_final_newline = true
 charset = utf-8
 indent_style = tab
 indent_size = 4


### PR DESCRIPTION
Multiple definitions with the same section name cause errors in Atom editor (I don't think they are actually strictly legal in ini files). I've just grouped everything from both `[*]` sections into one so there should be no change in behavior.