### PR TITLE
added EXT_CFLAGS to CFLAGS in order to enable native build for px4

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -22,7 +22,7 @@ LINKER		:= gcc
 WFLAGS		:= -Wall -Wextra -Werror=float-equal -Wuninitialized \
 	-Wunused-variable -Wdouble-promotion -pedantic -Wmissing-prototypes \
 	-Wmissing-declarations -Werror=undef
-CFLAGS		:= -g -fPIC -I $(INCLUDEDIR)
+CFLAGS		:= $(EXT_CFLAGS) -g -fPIC -I $(INCLUDEDIR)
 OPT_FLAGS	:= -O1
 LDFLAGS		:= -lm -lrt -pthread -shared -Wl,-soname,$(SONAME)
 


### PR DESCRIPTION
To build librobotcontrol for PX4 natively on BeagleBone board, an additional gcc flag is needed. This change is to make it possible to add the flag to the make command, e.g.,

make EXT_CFLAGS=-DRC_AUTOPILOT_EXT
or (to verify if the flag is applied) 
make EXT_CFLAGS=-DRC_AUTOPILOT_EXT SHELL='sh -x'
