### PR TITLE
pwm.c: do not unexport channels

### DIFF
--- a/library/src/io/pwm.c
+++ b/library/src/io/pwm.c
@@ -144,6 +144,9 @@ static int __export_channels(int ss)
  */
 static int __unexport_channels(int ss)
 {
+	/* At a minimum, the channels need to be disabled prior to being unexported */
+	return 0;
+
 	int unexport_fd=0;
 	char buf[MAXBUF];
 	int len;


### PR DESCRIPTION
The kernel complains that the PWM is not stopped ahead of being
unexported. This may or may not be the case, but in any case,
this helps avoid the kernel issue.

Fixes https://github.com/StrawsonDesign/librobotcontrol/issues/154